### PR TITLE
force-unwrap nil fields always crash

### DIFF
--- a/Sources/MongoDB/MongoCollection.swift
+++ b/Sources/MongoDB/MongoCollection.swift
@@ -407,7 +407,7 @@ public class MongoCollection {
      *  - returns:	A cursor to the documents that match the query criteria. When the find() method “returns documents,” the method is actually returning a cursor to the documents.
     */
 	public func find(query: BSON, fields: BSON? = nil, flags: MongoQueryFlag = MongoQueryFlag.None, skip: Int = 0, limit: Int = 0, batchSize: Int = 0) -> MongoCursor? {
-		let cursor = mongoc_collection_find(self.ptr!, flags.queryFlags, UInt32(skip), UInt32(limit), UInt32(batchSize), query.doc!, (fields == nil ? nil : fields!.doc)!, nil)
+		let cursor = mongoc_collection_find(self.ptr!, flags.queryFlags, UInt32(skip), UInt32(limit), UInt32(batchSize), query.doc!, (fields == nil ? nil : fields!.doc), nil)
 		guard cursor != nil else {
 			return nil
 		}


### PR DESCRIPTION
executable crashes in case of nil fields
