### PR TITLE
Fixed bug in the README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ func mongoHandler(request: WebRequest, _ response: WebResponse) {
 
     // Return the JSON string
     response.appendBody(string: returning)
-    response.requestCompleted()
+    response.completed()
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
The response object has no method requestCompleted() but rather it responds to completed()