### PR TITLE
Add newObjectId() func to BSON.OID

### DIFF
--- a/Sources/PerfectMongoDB/BSON.swift
+++ b/Sources/PerfectMongoDB/BSON.swift
@@ -512,6 +512,14 @@ public class BSON: CustomStringConvertible {
 			bson_oid_init_from_string(&oid, string)
 			self.oid = oid
 		}
+        public init() {
+            var oid = bson_oid_t()
+            bson_oid_init(&oid, nil)
+            self.oid = oid
+        }
+        public static func newObjectId() -> String {
+            return self.init().description
+        }
 	}
 	
 	/// Add the OID with the given key.

--- a/Tests/PerfectMongoDBTests/PerfectMongoDBTests.swift
+++ b/Tests/PerfectMongoDBTests/PerfectMongoDBTests.swift
@@ -905,6 +905,10 @@ class PerfectMongoDBTests: XCTestCase {
         }
     }
 
+    func testNewObjectIdGeneration() {
+        let objectId = BSON.OID.newObjectId()
+        XCTAssertTrue(objectId.characters.count == 24, "Should generate valid ObjectId")
+    }
 }
 
 extension PerfectMongoDBTests {
@@ -924,7 +928,8 @@ extension PerfectMongoDBTests {
             ("testDeleteDoc", testDeleteDoc),
             ("testCollectionFind", testCollectionFind),
             ("testCollectionDistinct", testCollectionDistinct),
-            ("testGridFS", testGridFS)
+            ("testGridFS", testGridFS),
+            ("testNewObjectIdGeneration", testNewObjectIdGeneration)
         ]
     }
 }


### PR DESCRIPTION
MongoDB uses special format for ObjectId. Here I've added a few functions to generate ObjectId. I will use them in my next fork of MongoDBStORM to save _id as ObjectId