### PR TITLE
Fix insert(documents:) error detection

### DIFF
--- a/Sources/PerfectMongoDB/MongoCollection.swift
+++ b/Sources/PerfectMongoDB/MongoCollection.swift
@@ -314,7 +314,7 @@ public class MongoCollection {
             // bson_destroy (doc)
         }
         
-        guard mongoc_bulk_operation_execute(bulk, &reply, &error) == 1 else {
+        guard mongoc_bulk_operation_execute(bulk, &reply, &error) != 0 else {
             return Result.fromError(error)
         }
         


### PR DESCRIPTION
mongoc_bulk_operation_execute only indicates an error when returning 0. Any non zero value indicates success.

See: http://mongoc.org/libmongoc/current/mongoc_bulk_operation_execute.html
